### PR TITLE
Allow building with ufbt

### DIFF
--- a/view_info.c
+++ b/view_info.c
@@ -2,7 +2,7 @@
  * See the LICENSE file for information about the license. */
 
 #include "app.h"
-#include <gui/view_i.h>
+#include <gui/view.h>
 #include <lib/toolbox/random_name.h>
 
 /* This view has subviews accessible navigating up/down. This


### PR DESCRIPTION
Only public headers are accessible when using [ufbt](https://github.com/flipperdevices/flipperzero-ufbt). This allows to build the app outside the firmware directory.