### PR TITLE
Fix the generation of signal files with custom presets

### DIFF
--- a/signal_file.c
+++ b/signal_file.c
@@ -43,11 +43,21 @@ bool save_signal(ProtoViewApp *app, const char *filename) {
             furi_string_printf(custom,
                 "Custom_preset_module: CC1101\n"
                  "Custom_preset_data: ");
-            for (int j = 0; regs[j]; j += 2) {
+
+            /* We will know the size of the preset data once we reach the end
+             * of the registers (null address). For now it's INT_MAX. */
+            int preset_data_size = INT_MAX;
+            bool patable_reached = false;
+            for(int j = 0; j <= preset_data_size; j += 2) {
+                // End reached, set the size to write the remaining 8 bytes (PATABLE)
+                if (!patable_reached && regs[j] == 0) {
+                    preset_data_size = j + 8;
+                    patable_reached = true;
+                }
                 furi_string_cat_printf(custom, "%02X %02X ",
                     (int)regs[j], (int)regs[j+1]);
             }
-            size_t len = furi_string_size(file_content);
+            size_t len = furi_string_size(custom);
             furi_string_set_char(custom,len-1,'\n');
             furi_string_cat(file_content,custom);
             furi_string_free(custom);


### PR DESCRIPTION
Fix the incomplete custom preset data and the line feed in the wrong location for the signal file generation code (#14).